### PR TITLE
Create Segregate-even-and-odd-nodes-in-LinkedList.py

### DIFF
--- a/Linked-List/Segregate-even-and-odd-nodes-in-LinkedList/Segregate-even-and-odd-nodes-in-LinkedList.py
+++ b/Linked-List/Segregate-even-and-odd-nodes-in-LinkedList/Segregate-even-and-odd-nodes-in-LinkedList.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+class ListNode:
+    def __init__(self, val=0, next=None):
+        self.val = val
+        self.next = next
+
+def odd_even_list(head: Optional[ListNode]) -> Optional[ListNode]:
+    # If the list is empty or has only one node, return the head as it is
+    if not head or not head.next:
+        return head
+
+    # Initialize pointers for odd and even nodes
+    odd = head
+    even = head.next
+    even_head = even  # Store the head of the even list to attach later
+
+    # Rearrange the odd and even nodes
+    while even and even.next:
+        odd.next = even.next  # Link the next odd node
+        odd = odd.next        # Move to the next odd node
+        even.next = odd.next  # Link the next even node
+        even = even.next      # Move to the next even node
+
+    # After all odd nodes are linked, attach the even list to the end
+    odd.next = even_head
+    return head


### PR DESCRIPTION
#25 

Explanation of logic:
Initial check: If the list is empty or has only one node, it’s returned as is.
Odd and even node initialization: The odd pointer starts at head, and the even pointer starts at head.next. The even_head pointer stores the head of the even nodes to reconnect the two lists later.
While loop: The loop runs until there are no more even nodes to process. The odd and even nodes are linked to their respective lists.
Reattaching even nodes: Finally, the even list (starting at even_head) is attached to the end of the odd list.
This implementation efficiently rearranges nodes in a single pass through the list with O(n) time complexity and O(1) space complexity.